### PR TITLE
Skip source parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ where the list contains a list of URLs we sent a webmention to or
 {:error, reason}
 ```
 
+If you already know the list of URL mentions, you can skip parsing the 
+source URL and send webmentions to all destinations URL (if they support it): 
+
+    destinations = ["http://example.org/", "http://other.org/"]
+    Webmentions.send_webmentions_for_urls("https://source.org", destinations)
+    
+It will behave as `Webmentions.send_webmentions/2` does.
+
 ## Dependencies
 
 We need [Floki](https://github.com/philss/floki) for HTML parsing and

--- a/lib/webmentions.ex
+++ b/lib/webmentions.ex
@@ -27,19 +27,12 @@ defmodule Webmentions do
     |> send_webmentions_for_links(source_url, document)
   end
 
-  defp extract_links_from_doc(content) do
-    Floki.find(content, "a[href]")
-    |> Enum.filter(fn x ->
-      s =
-        Floki.attribute(x, "rel")
-        |> List.first()
-        |> to_string
-
-      not String.contains?(s, "nofollow")
-    end)
+  def send_webmentions_for_links(source_url, targets) do
+    sent = Enum.map(targets, &handle_send_webmention(source_url, &1))
+    {:ok, sent}
   end
 
-  def send_webmentions_for_links(links, source_url, document) do
+  defp send_webmentions_for_links(links, source_url, document) do
     sent = Enum.map(links, &handle_send_webmention(&1, source_url, document))
     {:ok, sent}
   end
@@ -245,5 +238,17 @@ defmodule Webmentions do
     if Utils.blank?(ret),
       do: nil,
       else: hd(ret) |> elem(1)
+  end
+
+  defp extract_links_from_doc(content) do
+    Floki.find(content, "a[href]")
+    |> Enum.filter(fn x ->
+      s =
+        Floki.attribute(x, "rel")
+        |> List.first()
+        |> to_string
+
+      not String.contains?(s, "nofollow")
+    end)
   end
 end

--- a/test/webmentions_test.exs
+++ b/test/webmentions_test.exs
@@ -1,5 +1,5 @@
 defmodule WebmentionsTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   doctest Webmentions
 
   import Tesla.Mock


### PR DESCRIPTION
implements a `Webmentions.send_webmentions_for_links/2` which takes the source_url and a list of already parsed links to send webmentions to.