### PR TITLE
exclude links with URI schemes like mailto, tel

### DIFF
--- a/lib/webmentions.ex
+++ b/lib/webmentions.ex
@@ -260,6 +260,13 @@ defmodule Webmentions do
   defp extract_links_from_doc(content) do
     Floki.find(content, "a[href]")
     |> Enum.filter(fn x ->
+      case Floki.attribute(x, "href") |> List.first() do
+        "/" <> _ -> true
+        "http" <> _ -> true
+        _ -> false
+      end
+    end)
+    |> Enum.filter(fn x ->
       s =
         Floki.attribute(x, "rel")
         |> List.first()

--- a/test/webmentions_test.exs
+++ b/test/webmentions_test.exs
@@ -139,6 +139,21 @@ defmodule WebmentionsTest do
       assert Webmentions.send_webmentions("http://example.org") == {:ok, []}
     end
 
+    test "doesn't send a webmention to links with URI schemes (mailto, tel)" do
+      doc = %Tesla.Env{
+        status: 200,
+        body: "
+          <html class=\"h-entry\">
+            <a href=\"mailto:email@example.com\">email</a>
+            <a href=\"tel:+1234567890\">+1234567890</a>
+          </html>",
+        headers: [{"Link", "<http://example.org/webmentions>; rel=\"webmention\""}]
+      }
+
+      mock(fn _ -> {:ok, doc} end)
+      assert Webmentions.send_webmentions("http://example.org") == {:ok, []}
+    end
+
     test "successfully sends mentions to relative URLs" do
       doc = %Tesla.Env{
         status: 200,


### PR DESCRIPTION
Thanks for the library. It fails on URI with schemes like `tel`, `mailto`. I've added an additional filter step to only allow relative and http/https links, thus effectively filtering out any URI with a scheme.

```elixir
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom

    :erlang.atom_to_binary({:bad_scheme, 'tel'}, :utf8)
    (webmentions 2.0.0) lib/webmentions.ex:127: Webmentions.discover_endpoint/1
    (webmentions 2.0.0) lib/webmentions.ex:51: Webmentions.handle_send_webmention/2
```

Why are you filtering out also `nofollow` links?