### PR TITLE
fix Tesla error format parsing

### DIFF
--- a/lib/webmentions.ex
+++ b/lib/webmentions.ex
@@ -172,7 +172,7 @@ defmodule Webmentions do
       end
     else
       %Tesla.Env{status: code} -> {:error, code}
-      {:error, reason} -> {:error, Atom.to_string(reason)}
+      {:error, reason} -> {:error, reason}
       _ -> {:error, "unknown error"}
     end
   end


### PR DESCRIPTION
Not sure this would not create other issues somewhere else. I assume here we just need to "bubble up" the Tesla error back to its caller.

Closes https://github.com/ckruse/webmentions-elixir/issues/52